### PR TITLE
Place libraries after object files in the linker call

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,2 @@
 language: c
-before_install:
-  - sudo apt-get -qq update
-  - sudo apt-get install -y libc6-dev libc6-dev-i386
-  - sudo cp -v /usr/lib/x86_64-linux-gnu/libdl* /usr/lib/ || true
-
-script: make veryclean all install
+script: make veryclean all

--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,10 @@ CFLAGS=	-fPIC -fsigned-char -pipe -Wall -Wpointer-arith -Wwrite-strings \
 #-Wcast-align causes problems on solaris, but not serious ones
 LDFLAGS=	-g -rdynamic -lm
 #LDFLAGS_SOLARIS= -g -lsocket -lnsl -lm
-LDFLAGS_SOLARIS= -g -lsocket -lnsl -lm -ldl
-LDFLAGS_LINUX= -g  -rdynamic -ldl -lm
+LDFLAGS_SOLARIS= -g
+LIBS_SOLARIS= -lsocket -lnsl -lm -ldl
+LDFLAGS_LINUX= -g  -rdynamic
+LIBS_LINUX= -ldl -lm
 LIBCFLAGS= -shared
 CC=	gcc
 
@@ -33,10 +35,10 @@ all:	$(GLOBALOBJS) sendip $(PROTOS) sendip.1 sendip.spec
 sendip:	sendip.o	gnugetopt.o gnugetopt1.o compact.o
 	sh -c "if [ `uname` = Linux ] ; then \
 echo $(CC) -o $@ $(LDFLAGS_LINUX) $(CFLAGS) $+ ; \
-$(CC) -o $@ $(LDFLAGS_LINUX) $(CFLAGS) $+ ; \
+$(CC) -o $@ $(LDFLAGS_LINUX) $(CFLAGS) $+ $(LIBS_LINUX) ; \
 elif [ `uname` = SunOS ] ; then \
 echo $(CC) -o $@ $(LDFLAGS_SOLARIS) $(CFLAGS) $+ ;\
-$(CC) -o $@ $(LDFLAGS_SOLARIS) $(CFLAGS) $+ ;\
+$(CC) -o $@ $(LDFLAGS_SOLARIS) $(CFLAGS) $+ $(LIBS_SOLARIS) ;\
 else \
 echo $(CC) -o $@ $(LDFLAGS) $(CFLAGS) $+ ; \
 $(CC) -o $@ $(LDFLAGS) $(CFLAGS) $+ ; \


### PR DESCRIPTION
Ubuntu, amongst others, defaults to --as-needed when linking, which
means that the libraries to be linked against need to be specified after
the objects or the linker won't pick up the requirements correctly.

(I'll stop filing PRs for now, but this fixes the Travis CI builds.)